### PR TITLE
feat: Include grid-system components

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "orta.vscode-jest",
-    "coenraads.bracket-pair-colorizer",
+    "coenraads.bracket-pair-colorizer-2",
     "silvenon.mdx"
   ]
 }

--- a/src/Grid/Col.tsx
+++ b/src/Grid/Col.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import classNames from 'classnames';
+
+const DEVICE_SIZES = [
+  'xl' as const,
+  'lg' as const,
+  'md' as const,
+  'sm' as const,
+  'xs' as const,
+];
+
+type NumberAttr =
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12';
+
+type ColOrder = 'first' | 'last' | NumberAttr;
+type ColSize = boolean | 'auto' | NumberAttr;
+
+type ColSpec =
+  | ColSize
+  | { span?: ColSize; offset?: NumberAttr; order?: ColOrder };
+
+type ColProps = {
+  /**
+   * The number of columns to span on extra small devices (<576px)
+   */
+  xs?: ColSpec;
+  /**
+   * The number of columns to span on small devices (≥576px)
+   */
+  sm?: ColSpec;
+  /**
+   * The number of columns to span on medium devices (≥768px)
+   */
+  md?: ColSpec;
+  /**
+   * The number of columns to span on large devices (≥992px)
+   */
+  lg?: ColSpec;
+  /**
+   * The number of columns to span on extra large devices (≥1200px)
+   */
+  xl?: ColSpec;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+const Col = React.forwardRef<HTMLDivElement, ColProps>(function Col(
+  { children, className, ...rest },
+  ref
+) {
+  const prefix = 'ods-col';
+  const spans: string[] = [];
+  const classes: string[] = [];
+
+  DEVICE_SIZES.forEach((brkPoint) => {
+    const propValue = rest[brkPoint];
+    delete rest[brkPoint];
+
+    let span: ColSize | undefined;
+    let offset: NumberAttr | undefined;
+    let order: ColOrder | undefined;
+
+    if (typeof propValue === 'object' && propValue != null) {
+      ({ span = true, offset, order } = propValue);
+    } else {
+      span = propValue;
+    }
+
+    const infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
+
+    if (span)
+      spans.push(
+        span === true ? `${prefix}${infix}` : `${prefix}${infix}-${span}`
+      );
+
+    if (order != null) classes.push(`order${infix}-${order}`);
+    if (offset != null) classes.push(`offset${infix}-${offset}`);
+  });
+
+  if (!spans.length) {
+    spans.push(prefix); // plain 'ods-col'
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={classNames(...spans, ...classes, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});
+
+export default Col;

--- a/src/Grid/Col.tsx
+++ b/src/Grid/Col.tsx
@@ -22,14 +22,8 @@ type NumberAttr =
   | '10'
   | '11'
   | '12';
-
-type ColOrder = 'first' | 'last' | NumberAttr;
 type ColSize = boolean | 'auto' | NumberAttr;
-
-type ColSpec =
-  | ColSize
-  | { span?: ColSize; order?: ColOrder; offset?: NumberAttr };
-
+type ColSpec = ColSize | { span?: ColSize; offset?: NumberAttr };
 type ColProps = {
   /**
    * The number of columns to span on extra small devices (<576px)
@@ -67,10 +61,9 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>(function Col(
 
     let span: ColSize | undefined;
     let offset: NumberAttr | undefined;
-    let order: ColOrder | undefined;
 
     if (typeof propValue === 'object' && propValue) {
-      ({ span = true, offset, order } = propValue);
+      ({ span = true, offset } = propValue);
     } else {
       span = propValue;
     }
@@ -83,7 +76,6 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>(function Col(
         span === true ? `${prefix}${infix}` : `${prefix}${infix}-${span}`
       );
     }
-    if (order) classes.push(`order${infix}-${order}`);
     if (offset) classes.push(`offset${infix}-${offset}`);
   });
 

--- a/src/Grid/Col.tsx
+++ b/src/Grid/Col.tsx
@@ -76,7 +76,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>(function Col(
         span === true ? `${prefix}${infix}` : `${prefix}${infix}-${span}`
       );
     }
-    if (offset) classes.push(`offset${infix}-${offset}`);
+    if (offset) classes.push(`ods-offset${infix}-${offset}`);
   });
 
   // plain 'ods-col'

--- a/src/Grid/Col.tsx
+++ b/src/Grid/Col.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import './styles/col.scss';
+
 const DEVICE_SIZES = [
   'xs' as const,
   'sm' as const,

--- a/src/Grid/Col.tsx
+++ b/src/Grid/Col.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import classNames from 'classnames';
 
 const DEVICE_SIZES = [
-  'xl' as const,
-  'lg' as const,
-  'md' as const,
-  'sm' as const,
   'xs' as const,
+  'sm' as const,
+  'md' as const,
+  'lg' as const,
+  'xl' as const,
 ];
 
 type NumberAttr =
@@ -28,7 +28,7 @@ type ColSize = boolean | 'auto' | NumberAttr;
 
 type ColSpec =
   | ColSize
-  | { span?: ColSize; offset?: NumberAttr; order?: ColOrder };
+  | { span?: ColSize; order?: ColOrder; offset?: NumberAttr };
 
 type ColProps = {
   /**
@@ -58,8 +58,8 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>(function Col(
   ref
 ) {
   const prefix = 'ods-col';
-  const spans: string[] = [];
-  const classes: string[] = [];
+  const classes = [];
+  let hasAnySpan = false;
 
   DEVICE_SIZES.forEach((brkPoint) => {
     const propValue = rest[brkPoint];
@@ -69,7 +69,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>(function Col(
     let offset: NumberAttr | undefined;
     let order: ColOrder | undefined;
 
-    if (typeof propValue === 'object' && propValue != null) {
+    if (typeof propValue === 'object' && propValue) {
       ({ span = true, offset, order } = propValue);
     } else {
       span = propValue;
@@ -77,25 +77,21 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>(function Col(
 
     const infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
 
-    if (span)
-      spans.push(
+    if (span) {
+      hasAnySpan = true;
+      classes.push(
         span === true ? `${prefix}${infix}` : `${prefix}${infix}-${span}`
       );
-
-    if (order != null) classes.push(`order${infix}-${order}`);
-    if (offset != null) classes.push(`offset${infix}-${offset}`);
+    }
+    if (order) classes.push(`order${infix}-${order}`);
+    if (offset) classes.push(`offset${infix}-${offset}`);
   });
 
-  if (!spans.length) {
-    spans.push(prefix); // plain 'ods-col'
-  }
+  // plain 'ods-col'
+  if (!hasAnySpan) classes.unshift(prefix);
 
   return (
-    <div
-      ref={ref}
-      className={classNames(...spans, ...classes, className)}
-      {...rest}
-    >
+    <div ref={ref} className={classNames(classes, className)} {...rest}>
       {children}
     </div>
   );

--- a/src/Grid/Container.tsx
+++ b/src/Grid/Container.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import classNames from 'classnames';
+
+type ContainerProps = {
+  /**
+   * Allow the Container to fill all of its available horizontal space.
+   * @default false
+   */
+  fluid?: boolean;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+const Container = React.forwardRef<HTMLDivElement, ContainerProps>(
+  function Container({ fluid = false, children, className, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={classNames(
+          `ods-container${fluid ? '-fluid' : ''}`,
+          className
+        )}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+export default Container;

--- a/src/Grid/Container.tsx
+++ b/src/Grid/Container.tsx
@@ -6,12 +6,13 @@ import './styles/container.scss';
 type ContainerProps = {
   /**
    * Allow the Container to fill all of its available horizontal space.
+   * @default false
    */
   fluid?: boolean | 'sm' | 'md' | 'lg' | 'xl';
 } & React.ComponentPropsWithoutRef<'div'>;
 
 const Container = React.forwardRef<HTMLDivElement, ContainerProps>(
-  function Container({ children, fluid, className, ...rest }, ref) {
+  function Container({ children, fluid = false, className, ...rest }, ref) {
     const prefix = 'ods-container';
     const suffix = typeof fluid === 'string' ? `-${fluid}` : '-fluid';
 

--- a/src/Grid/Container.tsx
+++ b/src/Grid/Container.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import './styles/container.scss';
+
 type ContainerProps = {
   /**
    * Allow the Container to fill all of its available horizontal space.
-   * @default false
    */
-  fluid?: boolean;
+  fluid?: boolean | 'sm' | 'md' | 'lg' | 'xl';
 } & React.ComponentPropsWithoutRef<'div'>;
 
 const Container = React.forwardRef<HTMLDivElement, ContainerProps>(
-  function Container({ children, fluid = false, className, ...rest }, ref) {
+  function Container({ children, fluid, className, ...rest }, ref) {
+    const prefix = 'ods-container';
+    const suffix = typeof fluid === 'string' ? `-${fluid}` : '-fluid';
+
     return (
       <div
         ref={ref}
-        className={classNames(
-          `ods-container${fluid ? '-fluid' : ''}`,
-          className
-        )}
+        className={classNames(fluid ? `${prefix}${suffix}` : prefix, className)}
         {...rest}
       >
         {children}

--- a/src/Grid/Container.tsx
+++ b/src/Grid/Container.tsx
@@ -10,7 +10,7 @@ type ContainerProps = {
 } & React.ComponentPropsWithoutRef<'div'>;
 
 const Container = React.forwardRef<HTMLDivElement, ContainerProps>(
-  function Container({ fluid = false, children, className, ...rest }, ref) {
+  function Container({ children, fluid = false, className, ...rest }, ref) {
     return (
       <div
         ref={ref}

--- a/src/Grid/Row.tsx
+++ b/src/Grid/Row.tsx
@@ -8,6 +8,7 @@ type RowColWidth = '1' | '2' | '3' | '4' | '5' | '6';
 type RowProps = {
   /**
    * Removes the gutter spacing between `Col`s as well as any added negative margins.
+   * @default false
    */
   noGutters?: boolean;
   /**
@@ -33,7 +34,7 @@ type RowProps = {
 } & React.ComponentPropsWithoutRef<'div'>;
 
 const Row = React.forwardRef<HTMLDivElement, RowProps>(function Row(
-  { children, className, noGutters, xs, sm, md, lg, xl, ...rest },
+  { children, className, noGutters = false, xs, sm, md, lg, xl, ...rest },
   ref
 ) {
   return (

--- a/src/Grid/Row.tsx
+++ b/src/Grid/Row.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import classNames from 'classnames';
+
+type RowColWidth =
+  | 'auto'
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12';
+
+type RowProps = {
+  /**
+   * Removes the gutter spacing between `Col`s as well as any added negative margins.
+   * @default false
+   */
+  noGutters?: boolean;
+  /**
+   * The number of columns that will fit next to each other on extra small devices (<576px).
+   */
+  xs?: RowColWidth;
+  /**
+   * The number of columns that will fit next to each other on small devices (≥576px).
+   */
+  sm?: RowColWidth;
+  /**
+   * The number of columns that will fit next to each other on medium devices (≥768px)
+   */
+  md?: RowColWidth;
+  /**
+   * The number of columns that will fit next to each other on large devices (≥992px)
+   */
+  lg?: RowColWidth;
+  /**
+   * The number of columns that will fit next to each other on extra large devices (≥1200px)
+   */
+  xl?: RowColWidth;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+const Row = React.forwardRef<HTMLDivElement, RowProps>(function Row(
+  { children, className, noGutters, xs, sm, md, lg, xl, ...rest },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={classNames(
+        'ods-row',
+        noGutters && 'ods-no-gutters',
+        {
+          [`ods-row-${xs}`]: xs,
+          [`ods-row-sm-${sm}`]: sm,
+          [`ods-row-md-${md}`]: md,
+          [`ods-row-lg-${lg}`]: lg,
+          [`ods-row-xl-${xl}`]: xl,
+        },
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});
+
+export default Row;

--- a/src/Grid/Row.tsx
+++ b/src/Grid/Row.tsx
@@ -1,25 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
 
-type RowColWidth =
-  | 'auto'
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | '10'
-  | '11'
-  | '12';
+import './styles/row.scss';
+
+type RowColWidth = '1' | '2' | '3' | '4' | '5' | '6';
 
 type RowProps = {
   /**
    * Removes the gutter spacing between `Col`s as well as any added negative margins.
-   * @default false
    */
   noGutters?: boolean;
   /**
@@ -55,11 +43,11 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>(function Row(
         'ods-row',
         noGutters && 'ods-no-gutters',
         {
-          [`ods-row-${xs}`]: xs,
-          [`ods-row-sm-${sm}`]: sm,
-          [`ods-row-md-${md}`]: md,
-          [`ods-row-lg-${lg}`]: lg,
-          [`ods-row-xl-${xl}`]: xl,
+          [`ods-row-cols-${xs}`]: xs,
+          [`ods-row-cols-sm-${sm}`]: sm,
+          [`ods-row-cols-md-${md}`]: md,
+          [`ods-row-cols-lg-${lg}`]: lg,
+          [`ods-row-cols-xl-${xl}`]: xl,
         },
         className
       )}

--- a/src/Grid/__tests__/Col.test.tsx
+++ b/src/Grid/__tests__/Col.test.tsx
@@ -53,22 +53,22 @@ test('includes offsets', () => {
     <Col
       data-testid="grid-col"
       xs={{ span: '4', offset: '1' }}
-      md={{ span: '8', order: '1' }}
-      lg={{ order: 'last' }}
+      md={{ span: '8' }}
+      lg={{ offset: '2' }}
     />
   );
 
   expect(getByTestId('grid-col').className).toBe(
-    'ods-col-4 offset-1 ods-col-md-8 order-md-1 ods-col-lg order-lg-last'
+    'ods-col-4 offset-1 ods-col-md-8 ods-col-lg offset-lg-2'
   );
 });
 
 it('allows span to be false', () => {
   const { getByTestId } = render(
-    <Col data-testid="grid-col" xs="6" md={{ span: false, order: 'first' }} />
+    <Col data-testid="grid-col" xs="6" md={{ span: false }} />
   );
 
-  expect(getByTestId('grid-col').className).toBe('ods-col-6 order-md-first');
+  expect(getByTestId('grid-col').className).toBe('ods-col-6');
 });
 
 it('allows span to be auto', () => {

--- a/src/Grid/__tests__/Col.test.tsx
+++ b/src/Grid/__tests__/Col.test.tsx
@@ -44,7 +44,7 @@ test('includes sizes', () => {
   );
 
   expect(getByTestId('grid-col').className).toBe(
-    'ods-col-lg-12 ods-col-md-8 ods-col-4'
+    'ods-col-4 ods-col-md-8 ods-col-lg-12'
   );
 });
 
@@ -59,7 +59,7 @@ test('includes offsets', () => {
   );
 
   expect(getByTestId('grid-col').className).toBe(
-    'ods-col-lg ods-col-md-8 ods-col-4 order-lg-last order-md-1 offset-1'
+    'ods-col-4 offset-1 ods-col-md-8 order-md-1 ods-col-lg order-lg-last'
   );
 });
 
@@ -77,6 +77,6 @@ it('allows span to be auto', () => {
   );
 
   expect(getByTestId('grid-col').className).toBe(
-    'ods-col-lg-auto ods-col-md-auto'
+    'ods-col-md-auto ods-col-lg-auto'
   );
 });

--- a/src/Grid/__tests__/Col.test.tsx
+++ b/src/Grid/__tests__/Col.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Col from '../Col';
+
+test('renders element properly', () => {
+  const { getByTestId } = render(
+    <Col
+      data-testid="grid-col"
+      className="other-css-class__1 other-css-class__2"
+    >
+      Col rendering
+    </Col>
+  );
+
+  expect(getByTestId('grid-col')).toMatchInlineSnapshot(`
+    <div
+      class="ods-col other-css-class__1 other-css-class__2"
+      data-testid="grid-col"
+    >
+      Col rendering
+    </div>
+  `);
+});
+
+test('includes "ods-col" when xs is true', () => {
+  const { getByTestId } = render(<Col data-testid="grid-col" xs />);
+  expect(getByTestId('grid-col').className).toBe('ods-col');
+});
+
+test('includes "ods-col" when span of xs is true', () => {
+  const { getByTestId } = render(
+    <Col data-testid="grid-col" xs={{ span: true }}>
+      span:true
+    </Col>
+  );
+
+  expect(getByTestId('grid-col').className).toBe('ods-col');
+});
+
+test('includes sizes', () => {
+  const { getByTestId } = render(
+    <Col data-testid="grid-col" xs="4" md="8" lg={{ span: '12' }} />
+  );
+
+  expect(getByTestId('grid-col').className).toBe(
+    'ods-col-lg-12 ods-col-md-8 ods-col-4'
+  );
+});
+
+test('includes offsets', () => {
+  const { getByTestId } = render(
+    <Col
+      data-testid="grid-col"
+      xs={{ span: '4', offset: '1' }}
+      md={{ span: '8', order: '1' }}
+      lg={{ order: 'last' }}
+    />
+  );
+
+  expect(getByTestId('grid-col').className).toBe(
+    'ods-col-lg ods-col-md-8 ods-col-4 order-lg-last order-md-1 offset-1'
+  );
+});
+
+it('allows span to be false', () => {
+  const { getByTestId } = render(
+    <Col data-testid="grid-col" xs="6" md={{ span: false, order: 'first' }} />
+  );
+
+  expect(getByTestId('grid-col').className).toBe('ods-col-6 order-md-first');
+});
+
+it('allows span to be auto', () => {
+  const { getByTestId } = render(
+    <Col data-testid="grid-col" md="auto" lg={{ span: 'auto' }} />
+  );
+
+  expect(getByTestId('grid-col').className).toBe(
+    'ods-col-lg-auto ods-col-md-auto'
+  );
+});

--- a/src/Grid/__tests__/Col.test.tsx
+++ b/src/Grid/__tests__/Col.test.tsx
@@ -59,7 +59,7 @@ test('includes offsets', () => {
   );
 
   expect(getByTestId('grid-col').className).toBe(
-    'ods-col-4 offset-1 ods-col-md-8 ods-col-lg offset-lg-2'
+    'ods-col-4 ods-offset-1 ods-col-md-8 ods-col-lg ods-offset-lg-2'
   );
 });
 

--- a/src/Grid/__tests__/Col.test.tsx
+++ b/src/Grid/__tests__/Col.test.tsx
@@ -30,9 +30,7 @@ test('includes "ods-col" when xs is true', () => {
 
 test('includes "ods-col" when span of xs is true', () => {
   const { getByTestId } = render(
-    <Col data-testid="grid-col" xs={{ span: true }}>
-      span:true
-    </Col>
+    <Col data-testid="grid-col" xs={{ span: true }} />
   );
 
   expect(getByTestId('grid-col').className).toBe('ods-col');

--- a/src/Grid/__tests__/Container.test.tsx
+++ b/src/Grid/__tests__/Container.test.tsx
@@ -7,7 +7,6 @@ test('render element properly', () => {
   const { getByTestId } = render(
     <Container
       data-testid="grid-container"
-      style={{ width: 200 }}
       className="other-css-class__1 other-css-class__2"
     >
       Container rendering
@@ -18,7 +17,6 @@ test('render element properly', () => {
     <div
       class="ods-container other-css-class__1 other-css-class__2"
       data-testid="grid-container"
-      style="width: 200px;"
     >
       Container rendering
     </div>

--- a/src/Grid/__tests__/Container.test.tsx
+++ b/src/Grid/__tests__/Container.test.tsx
@@ -9,7 +9,7 @@ test('render element properly', () => {
       data-testid="grid-container"
       className="other-css-class__1 other-css-class__2"
     >
-      Container rendering
+      Container
     </Container>
   );
 
@@ -18,12 +18,23 @@ test('render element properly', () => {
       class="ods-container other-css-class__1 other-css-class__2"
       data-testid="grid-container"
     >
-      Container rendering
+      Container
     </div>
   `);
 });
 
 test('turns grid into "full-width" layout via "fluid" property set', () => {
-  const { getByText } = render(<Container fluid>Fluid Container</Container>);
-  expect(getByText('Fluid Container')).toHaveClass('ods-container-fluid');
+  const { getByTestId } = render(
+    <Container data-testid="grid-container" fluid />
+  );
+
+  expect(getByTestId('grid-container').className).toBe('ods-container-fluid');
+});
+
+test('includes size breakpoint class when fluid is set to sm, md, lg or xl', () => {
+  const { getByTestId } = render(
+    <Container data-testid="grid-container" fluid="sm" />
+  );
+
+  expect(getByTestId('grid-container').className).toBe('ods-container-sm');
 });

--- a/src/Grid/__tests__/Container.test.tsx
+++ b/src/Grid/__tests__/Container.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Container from '../Container';
+
+test('render element properly', () => {
+  const { getByTestId } = render(
+    <Container
+      data-testid="grid-container"
+      style={{ width: 200 }}
+      className="other-css-class__1 other-css-class__2"
+    >
+      Container rendering
+    </Container>
+  );
+
+  expect(getByTestId('grid-container')).toMatchInlineSnapshot(`
+    <div
+      class="ods-container other-css-class__1 other-css-class__2"
+      data-testid="grid-container"
+      style="width: 200px;"
+    >
+      Container rendering
+    </div>
+  `);
+});
+
+test('turns grid into "full-width" layout via "fluid" property set', () => {
+  const { getByText } = render(<Container fluid>Fluid Container</Container>);
+  expect(getByText('Fluid Container')).toHaveClass('ods-container-fluid');
+});

--- a/src/Grid/__tests__/Row.test.tsx
+++ b/src/Grid/__tests__/Row.test.tsx
@@ -25,38 +25,12 @@ test('render element properly', () => {
 
 test('render no-gutters correctly', () => {
   const { getByTestId } = render(<Row data-testid="grid-row" noGutters />);
-  expect(getByTestId('grid-row')).toHaveClass('ods-row ods-no-gutters');
+  expect(getByTestId('grid-row').className).toBe('ods-row ods-no-gutters');
 });
 
 test('include number sizes', () => {
-  const { getByTestId } = render(
-    <Row data-testid="grid-row" xs="3" sm="7" md="5" lg="1" xl="11" />
+  const { getByTestId } = render(<Row data-testid="grid-row" xs="4" md="6" />);
+  expect(getByTestId('grid-row').className).toBe(
+    'ods-row ods-row-cols-4 ods-row-cols-md-6'
   );
-
-  expect(getByTestId('grid-row')).toHaveClass('ods-row');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-3');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-sm-7');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-md-5');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-lg-1');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-xl-11');
-});
-
-test('include auto sizes', () => {
-  const { getByTestId } = render(
-    <Row
-      data-testid="grid-row"
-      xs="auto"
-      sm="auto"
-      md="auto"
-      lg="auto"
-      xl="auto"
-    />
-  );
-
-  expect(getByTestId('grid-row')).toHaveClass('ods-row');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-auto');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-sm-auto');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-md-auto');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-lg-auto');
-  expect(getByTestId('grid-row')).toHaveClass('ods-row-xl-auto');
 });

--- a/src/Grid/__tests__/Row.test.tsx
+++ b/src/Grid/__tests__/Row.test.tsx
@@ -24,20 +24,13 @@ test('render element properly', () => {
 });
 
 test('render no-gutters correctly', () => {
-  const { getByTestId } = render(
-    <Row data-testid="grid-row" noGutters>
-      no-gutters
-    </Row>
-  );
-
+  const { getByTestId } = render(<Row data-testid="grid-row" noGutters />);
   expect(getByTestId('grid-row')).toHaveClass('ods-row ods-no-gutters');
 });
 
 test('include number sizes', () => {
   const { getByTestId } = render(
-    <Row data-testid="grid-row" xs="3" sm="7" md="5" lg="1" xl="11">
-      include number sizes
-    </Row>
+    <Row data-testid="grid-row" xs="3" sm="7" md="5" lg="1" xl="11" />
   );
 
   expect(getByTestId('grid-row')).toHaveClass('ods-row');
@@ -57,9 +50,7 @@ test('include auto sizes', () => {
       md="auto"
       lg="auto"
       xl="auto"
-    >
-      include auto sizes
-    </Row>
+    />
   );
 
   expect(getByTestId('grid-row')).toHaveClass('ods-row');

--- a/src/Grid/__tests__/Row.test.tsx
+++ b/src/Grid/__tests__/Row.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Row from '../Row';
+
+test('render element properly', () => {
+  const { getByTestId } = render(
+    <Row
+      data-testid="grid-row"
+      className="other-css-class__1 other-css-class__2"
+    >
+      Row rendering
+    </Row>
+  );
+
+  expect(getByTestId('grid-row')).toMatchInlineSnapshot(`
+    <div
+      class="ods-row other-css-class__1 other-css-class__2"
+      data-testid="grid-row"
+    >
+      Row rendering
+    </div>
+  `);
+});
+
+test('render no-gutters correctly', () => {
+  const { getByTestId } = render(
+    <Row data-testid="grid-row" noGutters>
+      no-gutters
+    </Row>
+  );
+
+  expect(getByTestId('grid-row')).toHaveClass('ods-row ods-no-gutters');
+});
+
+test('include number sizes', () => {
+  const { getByTestId } = render(
+    <Row data-testid="grid-row" xs="3" sm="7" md="5" lg="1" xl="11">
+      include number sizes
+    </Row>
+  );
+
+  expect(getByTestId('grid-row')).toHaveClass('ods-row');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-3');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-sm-7');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-md-5');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-lg-1');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-xl-11');
+});
+
+test('include auto sizes', () => {
+  const { getByTestId } = render(
+    <Row
+      data-testid="grid-row"
+      xs="auto"
+      sm="auto"
+      md="auto"
+      lg="auto"
+      xl="auto"
+    >
+      include auto sizes
+    </Row>
+  );
+
+  expect(getByTestId('grid-row')).toHaveClass('ods-row');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-auto');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-sm-auto');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-md-auto');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-lg-auto');
+  expect(getByTestId('grid-row')).toHaveClass('ods-row-xl-auto');
+});

--- a/src/Grid/index.ts
+++ b/src/Grid/index.ts
@@ -2,4 +2,5 @@ import Container from './Container';
 import Row from './Row';
 import Col from './Col';
 
+export { Container, Row, Col };
 export default { Container, Row, Col };

--- a/src/Grid/index.ts
+++ b/src/Grid/index.ts
@@ -1,0 +1,5 @@
+import Container from './Container';
+import Row from './Row';
+import Col from './Col';
+
+export default { Container, Row, Col };

--- a/src/Grid/stories/Col.stories.mdx
+++ b/src/Grid/stories/Col.stories.mdx
@@ -10,7 +10,7 @@ The API documentation of the Col React component. Learn more about the props and
 ## Import
 
 ```javascript
-import { Col } from '@useblu/ocean-ui/Grid';
+import { Col } from '@useblu/ocean-components/dist/Grid';
 ```
 
 ## Props

--- a/src/Grid/stories/Col.stories.mdx
+++ b/src/Grid/stories/Col.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Col from '../Col';
+
+<Meta title="Components/Grid/Col" component={Col} />
+
+# Grid - Col API
+
+The API documentation of the Col React component. Learn more about the props and the CSS customization points.
+
+## Import
+
+```javascript
+import { Col } from '@useblu/ocean-ui/Grid';
+```
+
+## Props
+
+<Props component={Col} parameters />
+
+The ref is forwarded to the root element.
+
+Any other props supplied will be provided to the root element (native element).
+
+## CSS
+
+| Rule name          | Global class                        | Description                                                           |
+| ------------------ | ----------------------------------- | --------------------------------------------------------------------- |
+| root               | .ods-col                            | Styles applied to the root element when no breakpoint is passed.      |
+| col-xs             | .ods-col-[auto,1..12]               | Sets the width content at xs or all breakpoints.                      |
+| col-breakpoints    | .ods-col-[sm,md,lg,xl]-[auto,1..12] | Sets the width content until the specified breakpoint.                |
+| offset-xs          | .ods-offset-[1..11]                 | Increases the left margin of a column for xs or all breakpoints.      |
+| offset-breakpoints | .ods-offset-[sm,md,lg,xl]-[0..11]   | Increases the left margin of a column until the specified breakpoint. |
+
+- _Set the column value (for any breakpoint size) to "auto" to size columns based on the natural width of their content._
+
+- _Offsetting by the width of an entire row isn't possible_
+
+- _In addition to column clearing at responsive breakpoints, you may need to reset offsets (e.g., .ods-offset-md-0)_
+
+If that's not sufficient, you can check the [implementation of the component](https://github.com/Pagnet/ocean-ds-web/blob/master/src/Grid/Col.tsx) for more detail.

--- a/src/Grid/stories/Container.stories.mdx
+++ b/src/Grid/stories/Container.stories.mdx
@@ -10,7 +10,7 @@ The API documentation of the Container React component. Learn more about the pro
 ## Import
 
 ```javascript
-import { Container } from '@useblu/ocean-ui/Grid';
+import { Container } from '@useblu/ocean-components/dist/Grid';
 ```
 
 ## Props

--- a/src/Grid/stories/Container.stories.mdx
+++ b/src/Grid/stories/Container.stories.mdx
@@ -1,0 +1,32 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Container from '../Container';
+
+<Meta title="Components/Grid/Container" component={Container} />
+
+# Grid - Container API
+
+The API documentation of the Container React component. Learn more about the props and the CSS customization points.
+
+## Import
+
+```javascript
+import { Container } from '@useblu/ocean-ui/Grid';
+```
+
+## Props
+
+<Props component={Container} parameters />
+
+The ref is forwarded to the root element.
+
+Any other props supplied will be provided to the root element (native element).
+
+## CSS
+
+| Rule name             | Global class                 | Description                                          |
+| --------------------- | ---------------------------- | ---------------------------------------------------- |
+| container             | .ods-container               | Sets a `max-width` at each responsive breakpoint.    |
+| container-fluid       | .ods-container-fluid         | Sets a `width: 100%` at all breakpoints.             |
+| container-breakpoints | .ods-container-[sm,md,lg,xl] | Sets a `width: 100%` until the specified breakpoint. |
+
+If that's not sufficient, you can check the [implementation of the component](https://github.com/Pagnet/ocean-ds-web/blob/master/src/Grid/Container.tsx) for more detail.

--- a/src/Grid/stories/Grid.stories.mdx
+++ b/src/Grid/stories/Grid.stories.mdx
@@ -1,0 +1,167 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Container from '../Container';
+import Row from '../Row';
+import Col from '../Col';
+import '../styles/stories.scss';
+
+<Meta title="Components/Grid/Demos" />
+
+## Equal-width
+
+For example, here are two grid layouts that apply to every device and viewport, from xs to xl. Add any number of unit-less classes for each breakpoint you need and every column will be the same width.
+
+<Preview>
+  <Story
+    name="Equal-width"
+    parameters={{ controls: { hideNoControlsWarning: true } }}
+  >
+    <Container>
+      <Row>
+        <Col>1 of 2</Col>
+        <Col>2 of 2</Col>
+      </Row>
+      <Row>
+        <Col>1 of 3</Col>
+        <Col>2 of 3</Col>
+        <Col>3 of 3</Col>
+      </Row>
+    </Container>
+  </Story>
+</Preview>
+
+## Setting one column width
+
+Auto-layout for flexbox grid columns also means you can set the width of one column and have the sibling columns automatically resize around it. You may use predefined grid classes (as shown below), grid mixins, or inline widths. Note that the other columns will resize no matter the width of the center column.
+
+<Preview>
+  <Story
+    name="Setting one column width"
+    parameters={{ controls: { hideNoControlsWarning: true } }}
+  >
+    <Container>
+      <Row>
+        <Col>1 of 3</Col>
+        <Col xs="6">2 of 3 (wider)</Col>
+        <Col>3 of 3</Col>
+      </Row>
+      <Row>
+        <Col>1 of 3</Col>
+        <Col xs="5">2 of 3 (wider)</Col>
+        <Col>3 of 3</Col>
+      </Row>
+    </Container>
+  </Story>
+</Preview>
+
+## Mix and match
+
+<Preview>
+  <Story
+    name="Mix and match"
+    parameters={{ controls: { hideNoControlsWarning: true } }}
+  >
+    <Container>
+      <Row>
+        <Col md="8">.ods-col-md-8</Col>
+        <Col xs="6" md="4">
+          .ods-col-6 .ods-col-md-4
+        </Col>
+      </Row>
+      <Row>
+        <Col xs="6" md="4">
+          .ods-col-6 .ods-col-md-4
+        </Col>
+        <Col xs="6" md="4">
+          .ods-col-6 .ods-col-md-4
+        </Col>
+        <Col xs="6" md="4">
+          .ods-col-6 .ods-col-md-4
+        </Col>
+      </Row>
+      <Row>
+        <Col xs="6">.ods-col-6</Col>
+        <Col xs="6">.ods-col-6</Col>
+      </Row>
+    </Container>
+  </Story>
+</Preview>
+
+## Row columns
+
+Use these row columns classes to quickly create basic grid layouts or to control your card layouts.
+
+<Preview>
+  <Story
+    name="Row columns"
+    parameters={{ controls: { hideNoControlsWarning: true } }}
+  >
+    <Container>
+      <Row xs="1" sm="2" md="4">
+        <Col>Column</Col>
+        <Col>Column</Col>
+        <Col>Column</Col>
+        <Col>Column</Col>
+      </Row>
+    </Container>
+  </Story>
+</Preview>
+
+## Offsetting columns
+
+<Preview>
+  <Story
+    name="Offsetting columns"
+    parameters={{ controls: { hideNoControlsWarning: true } }}
+  >
+    <Container>
+      <Row>
+        <Col md="4">.ods-col-md-4</Col>
+        <Col md={{ span: '4', offset: '4' }}>
+          .ods-col-md-4 .ods-offset-md-4
+        </Col>
+      </Row>
+      <Row>
+        <Col md={{ span: '3', offset: '3' }}>
+          .ods.col-md-3 .ods.offset-md-3
+        </Col>
+        <Col md={{ span: '3', offset: '3' }}>
+          .ods.col-md-3 .ods.offset-md-3
+        </Col>
+      </Row>
+      <Row>
+        <Col md={{ span: '6', offset: '3' }}>
+          .ods-col-md-6 .ods-offset-md-3
+        </Col>
+      </Row>
+    </Container>
+  </Story>
+</Preview>
+
+## Nesting
+
+To nest your content with the default grid, add a new .ods-row and set of .ods-col-sm-\* columns within an existing .ods-col-sm-\* column.
+
+Nested rows should include a set of columns that add up to 12 or fewer (it is not required that you use all 12 available columns).
+
+<Preview>
+  <Story
+    name="Nesting"
+    parameters={{ controls: { hideNoControlsWarning: true } }}
+  >
+    <Container>
+      <Row>
+        <Col sm="9">
+          Level 1: .ods-col-sm-9
+          <Row>
+            <Col xs="8" sm="6">
+              Level 2: .ods-col-8 .ods-col-sm-6
+            </Col>
+            <Col xs="4" sm="6">
+              Level 2: .ods-col-4 .ods-col-sm-6
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+    </Container>
+  </Story>
+</Preview>

--- a/src/Grid/stories/Row.stories.mdx
+++ b/src/Grid/stories/Row.stories.mdx
@@ -10,7 +10,7 @@ The API documentation of the Row React component. Learn more about the props and
 ## Import
 
 ```javascript
-import { Row } from '@useblu/ocean-ui/Grid';
+import { Row } from '@useblu/ocean-components/dist/Grid';
 ```
 
 ## Props

--- a/src/Grid/stories/Row.stories.mdx
+++ b/src/Grid/stories/Row.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Row from '../Row';
+
+<Meta title="Components/Grid/Row" component={Row} />
+
+# Grid - Row API
+
+The API documentation of the Row React component. Learn more about the props and the CSS customization points.
+
+## Import
+
+```javascript
+import { Row } from '@useblu/ocean-ui/Grid';
+```
+
+## Props
+
+<Props component={Row} parameters />
+
+The ref is forwarded to the root element.
+
+Any other props supplied will be provided to the root element (native element).
+
+## CSS
+
+| Rule name            | Global class                       | Description                                                                                               |
+| -------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| root                 | .ods-row                           | Styles applied to the root element.                                                                       |
+| no-gutters           | .ods-no-gutters                    | Removes the negative margins from .ods-row and the horizontal padding from all immediate children columns |
+| row-cols-xs          | .ods-row-cols-[1..6]               | Sets the number of columns that best render your content and layout.                                      |
+| row-cols-breakpoints | .ods-row-cols-[sm,md,lg,xl]-[1..6] | Sets column widths in rows until the specified breakpoint.                                                |
+
+_Whereas normal .ods-col-\* classes apply to the individual columns (e.g., .ods-col-md-4), the **row columns classes** are set on the parent .ods-row as a shortcut._
+
+If that's not sufficient, you can check the [implementation of the component](https://github.com/Pagnet/ocean-ds-web/blob/master/src/Grid/Row.tsx) for more detail.

--- a/src/Grid/styles/_breakpoints.scss
+++ b/src/Grid/styles/_breakpoints.scss
@@ -1,0 +1,32 @@
+// Minimum breakpoint width. Null for the smallest (first) breakpoint.
+//
+//    >> breakpoint-min(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    576px
+@function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
+  $min: map-get($breakpoints, $name);
+  @return if($min != 0, $min, null);
+}
+
+// Returns a blank string if smallest breakpoint, otherwise returns the name with a dash in front.
+// Useful for making responsive utilities.
+//
+//    >> breakpoint-infix(xs, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    ""  (Returns a blank string)
+//    >> breakpoint-infix(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    "-sm"
+@function breakpoint-infix($name, $breakpoints: $grid-breakpoints) {
+  @return if(breakpoint-min($name, $breakpoints) == null, '', '-#{$name}');
+}
+
+// Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
+// Makes the @content apply to the given breakpoint and wider.
+@mixin media-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
+  $min: breakpoint-min($name, $breakpoints);
+  @if $min {
+    @media (min-width: $min) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}

--- a/src/Grid/styles/_functions.scss
+++ b/src/Grid/styles/_functions.scss
@@ -1,0 +1,29 @@
+// Ascending
+// Used to evaluate Sass maps like our grid breakpoints.
+@mixin _assert-ascending($map, $map-name) {
+  $prev-key: null;
+  $prev-num: null;
+  @each $key, $num in $map {
+    @if $prev-num == null or unit($num) == '%' or unit($prev-num) == '%' {
+      // Do nothing
+    } @else if not comparable($prev-num, $num) {
+      @warn "Potentially invalid value for #{$map-name}: This map must be in ascending order, but key '#{$key}' has value #{$num} whose unit makes it incomparable to #{$prev-num}, the value of the previous key '#{$prev-key}' !";
+    } @else if $prev-num >= $num {
+      @warn "Invalid value for #{$map-name}: This map must be in ascending order, but key '#{$key}' has value #{$num} which isn't greater than #{$prev-num}, the value of the previous key '#{$prev-key}' !";
+    }
+    $prev-key: $key;
+    $prev-num: $num;
+  }
+}
+
+// Starts at zero
+// Used to ensure the min-width of the lowest breakpoint starts at 0.
+@mixin _assert-starts-at-zero($map, $map-name: '$grid-breakpoints') {
+  @if length($map) > 0 {
+    $values: map-values($map);
+    $first-value: nth($values, 1);
+    @if $first-value != 0 {
+      @warn "First breakpoint in #{$map-name} must start at 0, but starts at #{$first-value}.";
+    }
+  }
+}

--- a/src/Grid/styles/_grid.scss
+++ b/src/Grid/styles/_grid.scss
@@ -1,0 +1,156 @@
+@import 'variables';
+@import 'breakpoints';
+
+/// Grid system
+//
+// Generate semantic grid columns with these mixins.
+
+@mixin make-container($gutter: $grid-gutter-width) {
+  width: 100%;
+  padding-right: $gutter / 2;
+  padding-left: $gutter / 2;
+  margin-right: auto;
+  margin-left: auto;
+  box-sizing: border-box;
+}
+
+// For each breakpoint, define the maximum width of the container in a media query
+@mixin make-container-max-widths(
+  $max-widths: $container-max-widths,
+  $breakpoints: $grid-breakpoints
+) {
+  @each $breakpoint, $container-max-width in $max-widths {
+    @include media-breakpoint-up($breakpoint, $breakpoints) {
+      max-width: $container-max-width;
+    }
+  }
+}
+
+@mixin make-col($size, $columns: $grid-columns) {
+  flex: 0 0 percentage($size / $columns);
+  // Add a `max-width` to ensure content within each column does not blow out
+  // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
+  // do not appear to require this.
+  max-width: percentage($size / $columns);
+  box-sizing: border-box;
+}
+
+@mixin make-row($gutter: $grid-gutter-width) {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -$gutter / 2;
+  margin-left: -$gutter / 2;
+  box-sizing: border-box;
+}
+
+@mixin make-col-offset($size, $columns: $grid-columns) {
+  $num: $size / $columns;
+  margin-left: if($num == 0, 0, percentage($num));
+  box-sizing: border-box;
+}
+
+// Row columns
+//
+// Specify on a parent element(e.g., .row) to force immediate children into NN
+// numberof columns. Supports wrapping to new lines, but does not do a Masonry
+// style grid.
+
+@mixin row-cols($count) {
+  & > * {
+    flex: 0 0 100% / $count;
+    max-width: 100% / $count;
+    box-sizing: border-box;
+  }
+}
+
+@mixin make-row-columns($breakpoints: $grid-breakpoints) {
+  @each $breakpoint in map-keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
+
+    @include media-breakpoint-up($breakpoint, $breakpoints) {
+      @if $grid-row-columns > 0 {
+        @for $i from 1 through $grid-row-columns {
+          .ods-row-cols#{$infix}-#{$i} {
+            @include row-cols($i);
+          }
+        }
+      }
+    }
+  }
+}
+
+// Columns
+//
+// Used only by Bootstrap to generate the correct number of grid classes given
+// any value of `$grid-columns`.
+
+@mixin make-grid-columns(
+  $columns: $grid-columns,
+  $gutter: $grid-gutter-width,
+  $breakpoints: $grid-breakpoints
+) {
+  // Common properties for all breakpoints
+  %grid-column {
+    position: relative;
+    width: 100%;
+    padding-right: $gutter / 2;
+    padding-left: $gutter / 2;
+    box-sizing: border-box;
+  }
+
+  @each $breakpoint in map-keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
+
+    @if $columns > 0 {
+      // Allow columns to stretch full width below their breakpoints
+      @for $i from 1 through $columns {
+        .ods-col#{$infix}-#{$i} {
+          @extend %grid-column;
+        }
+      }
+    }
+
+    .ods-col#{$infix},
+    .ods-col#{$infix}-auto {
+      @extend %grid-column;
+    }
+
+    @include media-breakpoint-up($breakpoint, $breakpoints) {
+      // Provide basic `.ods-col-{bp}` classes for equal-width flexbox columns
+      .ods-col#{$infix} {
+        flex-basis: 0;
+        flex-grow: 1;
+        min-width: 0;
+        max-width: 100%;
+        box-sizing: border-box;
+      }
+
+      .ods-col#{$infix}-auto {
+        flex: 0 0 auto;
+        width: auto;
+        max-width: 100%; // Reset earlier grid tiers
+        box-sizing: border-box;
+      }
+
+      @if $columns > 0 {
+        @for $i from 1 through $columns {
+          .ods-col#{$infix}-#{$i} {
+            @include make-col($i, $columns);
+          }
+        }
+      }
+
+      @if $columns > 0 {
+        // `$columns - 1` because offsetting by the width of an entire row isn't possible
+        @for $i from 0 through ($columns - 1) {
+          @if not($infix == '' and $i == 0) {
+            // Avoid emitting useless .offset-0
+            .ods-offset#{$infix}-#{$i} {
+              @include make-col-offset($i, $columns);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Grid/styles/_variables.scss
+++ b/src/Grid/styles/_variables.scss
@@ -1,0 +1,38 @@
+@import 'functions';
+
+// Grid breakpoints
+//
+// Define the minimum dimensions at which your layout will change,
+// adapting to different screen sizes, for use in media queries.
+
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+) !default;
+
+@include _assert-ascending($grid-breakpoints, '$grid-breakpoints');
+@include _assert-starts-at-zero($grid-breakpoints, '$grid-breakpoints');
+
+// Grid containers
+//
+// Define the maximum width of `.container` for different screen sizes.
+
+$container-max-widths: (
+  sm: 540px,
+  md: 720px,
+  lg: 960px,
+  xl: 1140px,
+) !default;
+
+@include _assert-ascending($container-max-widths, '$container-max-widths');
+
+// Grid columns
+//
+// Set the number of columns and specify the width of the gutters.
+
+$grid-columns: 12 !default;
+$grid-gutter-width: 16px !default;
+$grid-row-columns: 6 !default;

--- a/src/Grid/styles/col.scss
+++ b/src/Grid/styles/col.scss
@@ -1,0 +1,6 @@
+@import 'grid';
+
+// Columns
+//
+// Common styles for small and large grid columns
+@include make-grid-columns();

--- a/src/Grid/styles/container.scss
+++ b/src/Grid/styles/container.scss
@@ -1,0 +1,41 @@
+@import 'grid';
+
+// Single container class with breakpoint max-widths
+.ods-container {
+  @include make-container();
+  @include make-container-max-widths();
+}
+
+// 100% wide container at all breakpoints
+.ods-container-fluid {
+  @include make-container();
+}
+
+// Responsive containers that are 100% wide until a breakpoint
+@each $breakpoint, $container-max-width in $container-max-widths {
+  .ods-container-#{$breakpoint} {
+    @extend .ods-container-fluid;
+  }
+
+  @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
+    %responsive-container-#{$breakpoint} {
+      max-width: $container-max-width;
+    }
+
+    // Extend each breakpoint which is smaller or equal to the current breakpoint
+    $extend-breakpoint: true;
+
+    @each $name, $width in $grid-breakpoints {
+      @if ($extend-breakpoint) {
+        .ods-container#{breakpoint-infix($name, $grid-breakpoints)} {
+          @extend %responsive-container-#{$breakpoint};
+        }
+
+        // Once the current breakpoint is reached, stop extending
+        @if ($breakpoint == $name) {
+          $extend-breakpoint: false;
+        }
+      }
+    }
+  }
+}

--- a/src/Grid/styles/row.scss
+++ b/src/Grid/styles/row.scss
@@ -1,0 +1,20 @@
+@import 'grid';
+
+.ods-row {
+  @include make-row();
+}
+
+@include make-row-columns();
+
+// Remove the negative margin from default .row, then the horizontal padding
+// from all immediate children columns (to prevent runaway style inheritance).
+.ods-no-gutters {
+  margin-right: 0;
+  margin-left: 0;
+
+  > .ods-col,
+  > [class*='ods-col-'] {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}

--- a/src/Grid/styles/stories.scss
+++ b/src/Grid/styles/stories.scss
@@ -1,0 +1,9 @@
+.ods-row {
+  > .ods-col,
+  > [class^='ods-col-'] {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    background-color: #bbeffd;
+    border: 1px solid #61dafb;
+  }
+}

--- a/src/Typography/Typography.tsx
+++ b/src/Typography/Typography.tsx
@@ -40,7 +40,7 @@ export type TypographyProps = {
 } & React.ComponentPropsWithoutRef<'span'>;
 
 const Typography = React.forwardRef<unknown, TypographyProps>(
-  function Typography({ variant, children, className, ...rest }, ref) {
+  function Typography({ children, variant, className, ...rest }, ref) {
     const Component = defaultTypesMapping[variant] as React.ElementType;
 
     return (

--- a/src/Typography/Typography.tsx
+++ b/src/Typography/Typography.tsx
@@ -33,10 +33,6 @@ export type TypographyProps = {
    * The content of the component.
    */
   children: React.ReactNode;
-  /**
-   * The CSS class name of the wrapper element.
-   */
-  className?: string;
 } & React.ComponentPropsWithoutRef<'span'>;
 
 const Typography = React.forwardRef<unknown, TypographyProps>(

--- a/src/Typography/__tests__/Typography.test.tsx
+++ b/src/Typography/__tests__/Typography.test.tsx
@@ -8,7 +8,6 @@ test('render element properly', () => {
     <Typography
       variant="heading1"
       data-testid="typo-heading1"
-      style={{ width: 200 }}
       className="other-css-class__1 other-css-class__2"
     >
       Hello
@@ -19,7 +18,6 @@ test('render element properly', () => {
     <h1
       class="ods-typography ods-typography__heading1 other-css-class__1 other-css-class__2"
       data-testid="typo-heading1"
-      style="width: 200px;"
     >
       Hello
     </h1>

--- a/src/Typography/__tests__/Typography.test.tsx
+++ b/src/Typography/__tests__/Typography.test.tsx
@@ -3,21 +3,22 @@ import { render } from '@testing-library/react';
 
 import Typography, { defaultTypesMapping, Variant } from '../Typography';
 
-test('render element', () => {
-  const { getByText } = render(
+test('render element properly', () => {
+  const { getByTestId } = render(
     <Typography
       variant="heading1"
-      data-cy="typo-heading1"
+      data-testid="typo-heading1"
       style={{ width: 200 }}
+      className="other-css-class__1 other-css-class__2"
     >
       Hello
     </Typography>
   );
 
-  expect(getByText('Hello')).toMatchInlineSnapshot(`
+  expect(getByTestId('typo-heading1')).toMatchInlineSnapshot(`
     <h1
-      class="ods-typography ods-typography__heading1"
-      data-cy="typo-heading1"
+      class="ods-typography ods-typography__heading1 other-css-class__1 other-css-class__2"
+      data-testid="typo-heading1"
       style="width: 200px;"
     >
       Hello
@@ -37,20 +38,3 @@ test.each(Object.keys(defaultTypesMapping))(
     );
   }
 );
-
-test('render another class', () => {
-  const { getByText } = render(
-    <Typography
-      variant="paragraph"
-      data-cy="typo-heading1"
-      style={{ width: 200 }}
-      className="another-css-class__1 another-css-class__2"
-    >
-      My Text
-    </Typography>
-  );
-
-  expect(getByText('My Text')).toHaveClass(
-    `ods-typography ods-typography__paragraph another-css-class__1 another-css-class__2`
-  );
-});

--- a/src/Typography/stories/Typography.stories.mdx
+++ b/src/Typography/stories/Typography.stories.mdx
@@ -39,7 +39,7 @@ Any other props supplied will be provided to the root element (native element).
 
 | Rule name   | Global class                   | Description                                                  |
 | ----------- | ------------------------------ | ------------------------------------------------------------ |
-| Root        | .ods-typography                | Styles applied to the root element.                          |
+| root        | .ods-typography                | Styles applied to the root element.                          |
 | heading1    | .ods-typography\_\_heading1    | Styles applied to the root element if variant="heading1".    |
 | heading2    | .ods-typography\_\_heading2    | Styles applied to the root element if variant="heading2".    |
 | heading3    | .ods-typography\_\_heading3    | Styles applied to the root element if variant="heading3".    |
@@ -50,7 +50,7 @@ Any other props supplied will be provided to the root element (native element).
 | description | .ods-typography\_\_description | Styles applied to the root element if variant="description". |
 | caption     | .ods-typography\_\_caption     | Styles applied to the root element if variant="caption".     |
 
-If that's not sufficient, you can check the [implementation of the component](https://github.com/Pagnet/ocean-ds-web-web-web/blob/master/src/Typography/Typography.tsx) for more detail.
+If that's not sufficient, you can check the [implementation of the component](https://github.com/Pagnet/ocean-ds-web/blob/master/src/Typography/Typography.tsx) for more detail.
 
 ## Playground
 

--- a/src/Typography/stories/Typography.stories.mdx
+++ b/src/Typography/stories/Typography.stories.mdx
@@ -10,7 +10,7 @@ The API documentation of the Typography React component. Learn more about the pr
 ## Import
 
 ```javascript
-import { Typography } from '@useblu/ocean-ui';
+import { Typography } from '@useblu/ocean-components';
 ```
 
 ## Usage

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export { default as Typography } from './Typography';
 export * from './Typography';
+
+export { default as Grid } from './Grid';
+export * from './Grid';


### PR DESCRIPTION
# Creates a grid system to the ocean design system.

_Package: `@useblu/ocean-components@0.1.0-beta.4`_

## Usage
![Peek 2020-07-29 11-02](https://user-images.githubusercontent.com/3240432/88809933-1323e400-d18b-11ea-8a29-524fb878c87f.gif)

## Documentation
![Peek 2020-07-29 11-12](https://user-images.githubusercontent.com/3240432/88811027-72cebf00-d18c-11ea-9da2-ca8604aac785.gif)

## Inspirations

- https://material-ui.com/api/grid/
- https://getbootstrap.com/docs/4.5/layout/grid/
- https://react-bootstrap.github.io/layout/grid/