### PR TITLE
typography caption and lead

### DIFF
--- a/src/Typography/Typography.tsx
+++ b/src/Typography/Typography.tsx
@@ -11,7 +11,9 @@ export const defaultTypesMapping: Record<string, string> = {
   subtitle1: 'h6',
   subtitle2: 'h6',
   paragraph: 'p',
+  lead: 'p',
   description: 'p',
+  caption: 'p',
 };
 
 export type Variant =
@@ -22,7 +24,9 @@ export type Variant =
   | 'subtitle1'
   | 'subtitle2'
   | 'paragraph'
-  | 'description';
+  | 'lead'
+  | 'description'
+  | 'caption';
 
 export type TypographyProps = {
   /**

--- a/src/Typography/stories/Typography.stories.mdx
+++ b/src/Typography/stories/Typography.stories.mdx
@@ -44,6 +44,7 @@ Any other props supplied will be provided to the root element (native element).
 | .ods-typography\_\_subtitle1   | Styles applied to the root element if variant="subtitle1".   |
 | .ods-typography\_\_subtitle2   | Styles applied to the root element if variant="subtitle2".   |
 | .ods-typography\_\_paragraph   | Styles applied to the root element if variant="paragraph".   |
+| .ods-typography\_\_lead        | Styles applied to the root element if variant="lead".        |
 | .ods-typography\_\_description | Styles applied to the root element if variant="description". |
 | .ods-typography\_\_caption     | Styles applied to the root element if variant="caption".     |
 
@@ -72,7 +73,9 @@ If that's not sufficient, you can check the [implementation of the component](ht
             'subtitle1',
             'subtitle2',
             'paragraph',
+            'lead',
             'description',
+            'caption',
           ],
         },
       },

--- a/src/Typography/styles/typography.scss
+++ b/src/Typography/styles/typography.scss
@@ -61,6 +61,13 @@
     font-size: $font-size-xs;
   }
 
+  &__lead {
+    color: $color-interface-dark-deep;
+    font-family: $font-family-base;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-bold;
+  }
+
   &__description {
     @include texts;
     font-size: $font-size-xxs;


### PR DESCRIPTION
# Creates a Typography caption and lead to the ocean design system.

_Package: `@useblu/ocean-components@0.1.0-beta.19`_

## Usage
```js
import React from 'react';

import { Typography } from '@useblu/ocean-components';

const ExempleTypography = () => {
  return (
    <div className='page'>
       <Typography variant="lead">Hello</Typography>
       <Typography variant="caption">Hello</Typography>
    </div>
  )
}

export default ExempleTypography;
```

## Documentation

Link to storybook: 
- https://pagnet.github.io/ocean-ds-web/index.html?path=/docs/components-typography--usage#typography-api