### PR TITLE
Support:  Flat Publishing For Easier Import Paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ jobs:
           name: Publish package
           command: |
             # Setup variables
+            cp -rf package.json dist
+            cd dist
+            # Setup variables
             export VERSION_NUMBER=$(echo $CIRCLE_TAG | awk '{print substr($1,2); }')
             export TAG_NAME=$(echo $VERSION_NUMBER | grep -Po '[a-z]*')
             [ -z "$TAG_NAME" ] && TAG_NAME="latest"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 dist
 coverage
 storybook-static
+.tool-versions

--- a/package.json
+++ b/package.json
@@ -2,12 +2,9 @@
   "name": "@useblu/ocean-components",
   "version": "0.0.0-controlled-by-tags",
   "description": "React components that implement Ocean's Design System.",
-  "main": "dist/index.js",
-  "module": "dist/index.es.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "main": "index.js",
+  "module": "index.es.js",
+  "types": "index.d.ts",
   "keywords": [
     "react",
     "react-component",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,12 +11,12 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: `dist/${pkg.main}`,
       format: 'cjs',
       sourcemap: true,
     },
     {
-      file: pkg.module,
+      file: `dist/${pkg.module}`,
       format: 'esm',
       sourcemap: true,
     },


### PR DESCRIPTION
This tries to solve the problem mentioned in this [issue](https://github.com/Pagnet/ocean-ds-web/issues/353)

It was removed the `/dist` folder from the entry points in the `package.json ` file, instead, the folder will be set in the `rollupjs ` context, cause now when the build process occurs, the `package.json ` file will be copied to the dist folder. 

It also adds a dist command that runs an `npm publish`  inside the `dist` folder.

> also adds the .tool-versions in .gitignore file for a better asdf usage.