### PR TITLE
docs(readme): adjust ocean-ds.min.css path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm i @useblu/ocean-components
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import '@useblu/ocean-components/ocean-ds.min.css';
+import '@useblu/ocean-components/dist/ocean-ds.min.css';
 import { Button } from '@useblu/ocean-components';
 
 function App() {


### PR DESCRIPTION
## Description

Fix wrong location of ocean-ds.min.css in the README file.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No new tests. Only doc update

## Screenshots (if appropriate):

## Checklist:

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] All new and existing tests passed
